### PR TITLE
feat: add support for owned resources

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,11 +3,15 @@
 Contains Go scripts for programmatically deploying [K8s VPAs](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) 
 for every deployment/statefulset/daemonset resource in the
 cluster and then extracting the recommendations from each into a CSV format. Designed to be used as part of a pod
-rightsizing exercise whilst taking some of the toil away.
+rightsizing exercise whilst taking some of the toil away from committing all the VPA config to git.
 
 As part of the export it also includes the current container K8s resource requests for CPU/memory and calculates a diff from the
 VPA recommendation, to allow us to see over/under provisioned workloads. Additionally, it checks if the resource already
 has an HPA configured. This is to see if it's eligible for the resource being switched to "auto" VPA mode (doesn't work alongside HPA's). 
+
+If a particular resource is managed by another resource (has an owner reference) then the parent resource is targeted by the VPA
+instead. It is a requirement of VPA to only target the parent controller. An example is when a `Prometheus` CR manages
+a Statefulset which runs the actual pods. In this case the VPA needs to target the CR.
 
 Scripts:
 


### PR DESCRIPTION
VPAs are required to target the parent controller of a resource. This PR detects whether the deployment/statefulset/daemonset is managed by another resource and if so creates a VPA against the parent controller instead.